### PR TITLE
change python references to python2 for universal execution

### DIFF
--- a/core/shellcodes/database/Windows/xor.py
+++ b/core/shellcodes/database/Windows/xor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This xor encoder was developed completely by Justin Warner (@sixdub)
 # Thanks a lot for letting us add this in!

--- a/core/shellcodes/shellcodes.cpp
+++ b/core/shellcodes/shellcodes.cpp
@@ -48,7 +48,7 @@ void genshellcode(int argp, string os, string type, string a1, string a2)
     outfile << session;
     outfile.close();
 
-    system("python session.py");
+    system("python2 session.py");
 
     cout << "\n";
     remove("session.py");


### PR DESCRIPTION
Changed references to python to python2 instead. In Arch Linux the default python installation is python3, leading to the following issue:

```
l0l > use linux/bin_sh
l0l:shellcode(linux/bin_sh) > generate
  File "session.py", line 8
    char shellcode [] = "%s";""" % shellcode
                               ^
SyntaxError: Missing parentheses in call to 'print'
```

This issue can be fixed by defaulting to python2 instead.