### PR TITLE
Handle Ctrl-D/EOF properly.

### DIFF
--- a/l0l.cpp
+++ b/l0l.cpp
@@ -33,6 +33,10 @@ int main(int argc, char * argv[]){
 
         strtok(command, " ");
 
+        if (cin.eof()) {
+            closeApp();
+        }
+
         if (strlen(command) == 0 || command[0] == '\r' || command[0] == '\n');
 
         // Commands..


### PR DESCRIPTION
Sending EOF (via a Ctrl-D) currently makes the app looping indefinitely since it cannot parse this.
Hence we check if we got EOF before trying to make sense of the input.