### PR TITLE
Update .gitignore to handle the compiled binary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 *.out
 *.app
 *.pyc
+
+# binary
+l0l


### PR DESCRIPTION
This is pretty much self-explanatory. It now adds the compiled binary into the git ignored files.