### PR TITLE
clean up makefile, add clean/install/uninstall with DESTDIR option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,19 @@
-l0l: l0l.cpp
-	g++ -o l0l l0l.cpp 
+CC = g++
+CFLAGS= -g -Wall
+TARGET = l0l
+
+$(TARGET): $(TARGET).cpp
+	$(CC) -o $(TARGET) $(TARGET).cpp
+
+#linux only
+clean:
+	rm $(TARGET)
+
+install:
+	mkdir -p $(DESTDIR)/usr/share/$(TARGET)
+	cp -a core __init__.py $(TARGET) $(DESTDIR)/usr/share/$(TARGET)
+	mkdir -p $(DESTDIR)/usr/bin/
+	cp l0l.sh $(DESTDIR)/usr/bin/$(TARGET)
+
+uninstall:
+	rm -rf $(DESTDIR)/usr/share/$(TARGET) $(DESTDIR)/usr/bin/$(TARGET)

--- a/core/shellcodes/s_console.cpp
+++ b/core/shellcodes/s_console.cpp
@@ -325,7 +325,7 @@ do{
 
         else {
             cout <<
-                    "\t\t\No option. Just use generate.\n\n";
+                    "\t\tNo option. Just use generate.\n\n";
         }
 
         // ..

--- a/l0l.sh
+++ b/l0l.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd /usr/share/l0l
+./l0l "$@"


### PR DESCRIPTION
Cleaned up the Makefile. Added the following:

make clean: remove the binary from directory
make install: install binary and necessary files, wrapper script (l0l.sh)
make uninstall: uninstall binary and files

DESTDIR option under install/uninstall is useful for installing on chroots. F.e.:
```
# make install DESTDIR=$CHROOT
```
where $CHROOT may point to any directory in the system.

l0l.sh gives the ability to run l0l from under /usr/bin/

A new user will follow the procedure below to install and use l0l:
```
$ make
# make install
$ l0l
```

Edit: Fixed a missed escape character to avoid compilation error

Additions etc. are welcome