### PR TITLE
add sudo to wrapper script

### DIFF
--- a/l0l.sh
+++ b/l0l.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cd /usr/share/l0l
-./l0l "$@"
+sudo ./l0l "$@"


### PR DESCRIPTION
In my testing of the wrapper script, I noticed the following error when trying to generate shellcodes:

```
l0l:shellcode(linux/bin_sh) > generate
python2: can't open file 'session.py': [Errno 2] No such file or directory
```
This is happening because a normal user has insufficient priviledges to generate the `session.py` file.

By adding sudo to the wrapper script, this issue can be solved.

```
l0l > use linux/bin_sh
l0l:shellcode(linux/bin_sh) > generate

char shellcode [] = "\x31\xc0\x40\x74\x15\x31\xc0\x50\x68\x2f\x2f\x73\x68\x68\x2f\x62\x69\x6e\x89\xe3\x89\xc2\xb0\x0b\xcd\x80\xf7\xe6\x52\x48\xbb\x2f\x62\x69\x6e\x2f\x2f\x73\x68\x53\x48\x8d\x3c\x24\xb0\x3b\x0f\x05";
```
