### PR TITLE
streamline the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,50 @@
+#variables
 CC = g++
 CFLAGS= -g -Wall
 TARGET = l0l
+WRAPPER = l0l.sh
+#commands
+RM = rm -f
+RMDIR = rm -rf
+CP = cp
+CPDIR = cp -a
+MKDIR_RX = install -dm755
+MKDIR_RO = install -dm644
+INSTALL_RX = install -Dm755
+INSTALL_RO = install -Dm644
+# locations
+PREFIX = /usr
+SHAREDIR = $(DESTDIR)$(PREFIX)/share
+BINDIR = $(DESTDIR)$(PREFIX)/bin
+LICENSEDIR = $(SHAREDIR)/licenses
 
 $(TARGET): $(TARGET).cpp
 	$(CC) -o $(TARGET) $(TARGET).cpp
 
+# to see all compilation errors & warnings
+verbose:
+	$(CC) $(CFLAGS) -o $(TARGET) $(TARGET).cpp
+
 #linux only
 clean:
-	rm $(TARGET)
+	$(RM) $(TARGET)
 
 install:
+	# make
 	$(CC) -o $(TARGET) $(TARGET).cpp
-	mkdir -p $(DESTDIR)/usr/share/$(TARGET)
-	cp -a core __init__.py $(TARGET) $(DESTDIR)/usr/share/$(TARGET)
-	mkdir -p $(DESTDIR)/usr/bin/
-	cp l0l.sh $(DESTDIR)/usr/bin/$(TARGET)
+	# install files to share
+	$(MKDIR_RX) $(SHAREDIR)/$(TARGET)
+	$(INSTALL_RX) __init__.py $(TARGET) $(SHAREDIR)/$(TARGET)
+	$(CPDIR) core $(SHAREDIR)/$(TARGET)
+	# install wrapper to bin
+	$(INSTALL_RX) $(WRAPPER) $(BINDIR)/$(TARGET)
+	$(MKDIR_RO) $(LICENSEDIR)/$(TARGET)
+	# install license
+	$(INSTALL_RO) LICENSE $(LICENSEDIR)/$(TARGET)
 
 uninstall:
-	rm -rf $(DESTDIR)/usr/share/$(TARGET) $(DESTDIR)/usr/bin/$(TARGET)
+	# remove executable from path
+	$(RM) $(BINDIR)/$(TARGET)
+	# remove files from share
+	$(RMDIR) $(SHAREDIR)/$(TARGET)
+	$(RMDIR) $(LICENSEDIR)/$(TARGET)


### PR DESCRIPTION
Added some new functionalities to the Makefile and improved it.

make verbose: see all compilation errors and warnings with the use of `-g` and `-Wall` flags

Improved make install and make uninstall using the command `install` to create read-only and read-execute directories and copy files with correct permissions.
make install now also installs the license.

make uninstall is now a bit safer using `rm -rf` only when necessary.

Additions etc. are welcome